### PR TITLE
Issue #35: Fix deprecated warning for optional parameter before required parameter

### DIFF
--- a/footnotes.module
+++ b/footnotes.module
@@ -60,8 +60,10 @@ function _footnotes_settings($form, &$form_state, $filter, $format) {
 /**
  * The bulk of filtering work is done here.
  */
-function _footnotes_filter($text = '', $filter, $format) {
-
+function _footnotes_filter($text, $filter, $format) {
+  if (is_null($text)) {
+    $text = '';
+  }
   // Supporting both [fn] and <fn> now.
   // Thanks to fletchgqc http://drupal.org/node/268026.
   // Convert all square brackets to angle brackets. This way all further code

--- a/footnotes.module
+++ b/footnotes.module
@@ -61,6 +61,7 @@ function _footnotes_settings($form, &$form_state, $filter, $format) {
  * The bulk of filtering work is done here.
  */
 function _footnotes_filter($text, $filter, $format) {
+
   // Supporting both [fn] and <fn> now.
   // Thanks to fletchgqc http://drupal.org/node/268026.
   // Convert all square brackets to angle brackets. This way all further code

--- a/footnotes.module
+++ b/footnotes.module
@@ -61,9 +61,6 @@ function _footnotes_settings($form, &$form_state, $filter, $format) {
  * The bulk of filtering work is done here.
  */
 function _footnotes_filter($text, $filter, $format) {
-  if (is_null($text)) {
-    $text = '';
-  }
   // Supporting both [fn] and <fn> now.
   // Thanks to fletchgqc http://drupal.org/node/268026.
   // Convert all square brackets to angle brackets. This way all further code


### PR DESCRIPTION
Fixes #35 

I put in a check for `$text` being `null` just in case. I'm not sure when might arise, if at all.